### PR TITLE
Fix version of kong alpine in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:alpine
+FROM kong:2.8.1-alpine
 
 LABEL description="Alpine + Kong  + kong-oidc plugin"
 


### PR DESCRIPTION
Hello!
I propose to fix the version of kong alpine in the Dockerfile.
The build wasn't working anymore since the release of version 3.0.0 of Kong.

The error was in the logs of the container of "kong" :

![MicrosoftTeams-image](https://user-images.githubusercontent.com/37326143/190440869-83aeec45-8606-47d1-9f87-495ca5cf9493.png)